### PR TITLE
fix hand-object matching issue？

### DIFF
--- a/lib/model/utils/matching.py
+++ b/lib/model/utils/matching.py
@@ -20,7 +20,7 @@ def filter_object(obj_dets, hand_dets):
             continue
         else: # hand is in-contact
             hand_cc = np.array(calculate_center(hand_dets[i,:4])) # hand center points
-            point_cc = np.array([(hand_cc[0]+hand_dets[i,6]*10000*hand_dets[i,7]), (hand_cc[1]+hand_dets[i,6]*10000*hand_dets[i,8])]) # extended points (hand center + offset)
+            point_cc = np.array([(hand_cc[0]+hand_dets[i,6]*1000*hand_dets[i,7]), (hand_cc[1]+hand_dets[i,6]*1000*hand_dets[i,8])]) # extended points (hand center + offset)
             dist = np.sum((object_cc_list - point_cc)**2,axis=1)
             dist_min = np.argmin(dist) # find the nearest 
             img_obj_id.append(dist_min)

--- a/lib/model/utils/net_utils.py
+++ b/lib/model/utils/net_utils.py
@@ -176,7 +176,7 @@ def filter_object(obj_dets, hand_dets):
             img_obj_id.append(-1)
             continue
         hand_cc = np.array(calculate_center(hand_dets[i,:4]))
-        point_cc = np.array([(hand_cc[0]+hand_dets[i,6]*10000*hand_dets[i,7]), (hand_cc[1]+hand_dets[i,6]*10000*hand_dets[i,8])])
+        point_cc = np.array([(hand_cc[0]+hand_dets[i,6]*1000*hand_dets[i,7]), (hand_cc[1]+hand_dets[i,6]*1000*hand_dets[i,8])])
         dist = np.sum((object_cc_list - point_cc)**2,axis=1)
         dist_min = np.argmin(dist)
         img_obj_id.append(dist_min)


### PR DESCRIPTION
Solved a problem where the dataset script was multiplied by 0.001

```
# voc_dataset.py
mag = obj.find('magnitude')
mag = 0 if self._is_not_legimate(mag) else float(mag.text) * 0.001 # balance scale
magnitude[ix] = mag
```

However, when matching, it was multiplied by 10000.

`point_cc = np.array([(hand_cc[0]+hand_dets[i,6]*10000*hand_dets[i,7]), (hand_cc[1]+hand_dets[i,6]*10000*hand_dets[i,8])])
`

So, I modified scaling on code.