### PR TITLE
Update CUDA extensions for newer PyTorch

### DIFF
--- a/lib/model/csrc/cuda/ROIAlign_cuda.cu
+++ b/lib/model/csrc/cuda/ROIAlign_cuda.cu
@@ -1,10 +1,12 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
 
-#include <THC/THC.h>
+//#include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
+#include "common.hpp"
 
 // TODO make it in a common file
 #define CUDA_1D_KERNEL_LOOP(i, n)                            \
@@ -276,7 +278,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   dim3 block(512);
 
   if (output.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return output;
   }
 
@@ -294,7 +296,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
          rois.contiguous().data<scalar_t>(),
          output.data<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  AT_CUDA_CHECK(cudaGetLastError());
   return output;
 }
 
@@ -322,7 +324,7 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_input;
   }
 
@@ -341,6 +343,6 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          grad_input.data<scalar_t>(),
          rois.contiguous().data<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  AT_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }

--- a/lib/model/csrc/cuda/ROIPool_cuda.cu
+++ b/lib/model/csrc/cuda/ROIPool_cuda.cu
@@ -1,10 +1,12 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
 
-#include <THC/THC.h>
+//#include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
+#include "common.hpp"
 
 
 // TODO make it in a common file
@@ -130,7 +132,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
   dim3 block(512);
 
   if (output.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return std::make_tuple(output, argmax);
   }
 
@@ -148,7 +150,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
          output.data<scalar_t>(),
          argmax.data<int>());
   });
-  THCudaCheck(cudaGetLastError());
+  AT_CUDA_CHECK(cudaGetLastError());
   return std::make_tuple(output, argmax);
 }
 
@@ -178,7 +180,7 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    AT_CUDA_CHECK(cudaGetLastError());
     return grad_input;
   }
 
@@ -197,6 +199,6 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
          grad_input.data<scalar_t>(),
          rois.contiguous().data<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  AT_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }

--- a/lib/model/csrc/cuda/common.hpp
+++ b/lib/model/csrc/cuda/common.hpp
@@ -1,0 +1,119 @@
+
+#include <cuda.h>
+#include <torch/types.h>
+#include <cuda_runtime.h>
+#include <c10/util/Half.h>
+
+namespace math_ops {
+
+// exp func
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Exp(scalar_t x) {
+    return exp(x);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Exp(c10::Half x) {
+    // return expf(static_cast<float>(x));
+    return hexp(x);
+}
+
+//
+// log func
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Log(scalar_t x) {
+    return log(x);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Log(c10::Half x) {
+    // return logf(static_cast<float>(x));
+    return hlog(x);
+}
+
+// 
+// log1p
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Log1p(scalar_t x) {
+    return log1p(x);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Log1p(c10::Half x) {
+    return log1p(static_cast<float>(x));
+}
+
+// 
+// pow
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Pow(scalar_t x, scalar_t y) {
+    return pow(x, y);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Pow(c10::Half x, c10::Half y) {
+    return pow(static_cast<float>(x), static_cast<float>(y));
+}
+
+// sqrt
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Sqrt(scalar_t x) {
+    return sqrt(x);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Sqrt(c10::Half x) {
+    return sqrtf(static_cast<float>(x));
+}
+
+// rsqrt
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Rsqrt(scalar_t x) {
+    return rsqrt(x);
+}
+
+template<>
+__forceinline__ __device__
+c10::Half Rsqrt(c10::Half x) {
+    return rsqrtf(static_cast<float>(x));
+}
+
+
+// abs func
+template<typename scalar_t>
+__forceinline__ __device__
+scalar_t Abs(scalar_t x) {
+    return x > scalar_t(0.) ? x : -x;
+}
+
+}
+
+
+/**
+   Computes ceil(a / b)
+*/
+template <typename T>
+__host__ __device__ __forceinline__ T THCCeilDiv(T a, T b) {
+  return (a + b - 1) / b;
+}
+
+/**
+   Computes ceil(a / b) * b; i.e., rounds up `a` to the next highest
+   multiple of b
+*/
+template <typename T>
+__host__ __device__ __forceinline__ T THCRoundUp(T a, T b) {
+  return THCCeilDiv(a, b) * b;
+}
+

--- a/lib/model/csrc/cuda/nms.cu
+++ b/lib/model/csrc/cuda/nms.cu
@@ -1,8 +1,9 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/ceil_div.h>
 
-#include <THC/THC.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <THC/THCDeviceUtils.cuh>
 
 #include <vector>
@@ -61,7 +62,7 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
         t |= 1ULL << i;
       }
     }
-    const int col_blocks = THCCeilDiv(n_boxes, threadsPerBlock);
+    const int col_blocks = at::ceil_div(n_boxes, threadsPerBlock);
     dev_mask[cur_box_idx * col_blocks + col_start] = t;
   }
 }
@@ -76,20 +77,18 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
 
   int boxes_num = boxes.size(0);
 
-  const int col_blocks = THCCeilDiv(boxes_num, threadsPerBlock);
+  const int col_blocks = at::ceil_div(boxes_num, threadsPerBlock);
 
   scalar_t* boxes_dev = boxes_sorted.data<scalar_t>();
 
-  THCState *state = at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
-
   unsigned long long* mask_dev = NULL;
-  //THCudaCheck(THCudaMalloc(state, (void**) &mask_dev,
+  //C10_CUDA_CHECK(THCudaMalloc(state, (void**) &mask_dev,
   //                      boxes_num * col_blocks * sizeof(unsigned long long)));
 
-  mask_dev = (unsigned long long*) THCudaMalloc(state, boxes_num * col_blocks * sizeof(unsigned long long));
+  mask_dev = (unsigned long long*) c10::cuda::CUDACachingAllocator::raw_alloc(boxes_num * col_blocks * sizeof(unsigned long long));
 
-  dim3 blocks(THCCeilDiv(boxes_num, threadsPerBlock),
-              THCCeilDiv(boxes_num, threadsPerBlock));
+  dim3 blocks(at::ceil_div(boxes_num, threadsPerBlock),
+              at::ceil_div(boxes_num, threadsPerBlock));
   dim3 threads(threadsPerBlock);
   nms_kernel<<<blocks, threads>>>(boxes_num,
                                   nms_overlap_thresh,
@@ -97,7 +96,7 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
                                   mask_dev);
 
   std::vector<unsigned long long> mask_host(boxes_num * col_blocks);
-  THCudaCheck(cudaMemcpy(&mask_host[0],
+  C10_CUDA_CHECK(cudaMemcpy(&mask_host[0],
                         mask_dev,
                         sizeof(unsigned long long) * boxes_num * col_blocks,
                         cudaMemcpyDeviceToHost));
@@ -122,7 +121,6 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
     }
   }
 
-  THCudaFree(state, mask_dev);
   // TODO improve this part
   return std::get<0>(order_t.index({
                        keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(


### PR DESCRIPTION
## Summary

Newer PyTorch/CUDA builds no longer expose the old THC runtime APIs used by these CUDA extensions. That makes the ROIAlign, ROIPool, and NMS CUDA code harder or impossible to build on newer environments.

This PR moves the extension code toward modern ATen/C10 CUDA APIs. It replaces `THCudaCheck` with AT/C10 CUDA checks, uses the C10 CUDA caching allocator for the NMS mask allocation, and adds shared helper definitions needed by the ROI kernels.

## Verification

- The original PR did not record a test command.